### PR TITLE
Added more information about launching blender from console on Mac OS

### DIFF
--- a/getting_started/setup.md
+++ b/getting_started/setup.md
@@ -16,7 +16,9 @@ Armory bundle comes with everything you need.
 
 ## Troubleshooting
 
-- To see error messages, start Blender from console or press `Blender - Window - Toggle System Console` on Windows.
+To see error messages, start Blender from console. 
+- Or on Windows press `Blender - Window - Toggle System Console`.
+- Or on Mac OS launch terminal then use the open command example `open /Applications/Armory/blender.app/Contents/MacOS/blender`.
 - When naming things, prefer unaccented alphabetical letters `A-Z`.
 - If `MSVCP140.dll` is missing, install [Visual C++ Redistributable for Visual Studio 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48145).
 - For old graphics cards, select `Low` preset in `Blender - Properties - Render - Armory Render Path`.


### PR DESCRIPTION
Added more detailed information on how to launch blender on Mac OS so that we can see debug information from Armory. This may be helpful to other new users.